### PR TITLE
Remove --runtime-config parameter

### DIFF
--- a/kops
+++ b/kops
@@ -355,7 +355,6 @@ def _cmd_create(args):
             '--master-volume-size', args.master_volume_size,
             '--node-volume-size', args.worker_volume_size,
             '--ssh-public-key', pub_key_path, '--authorization', 'RBAC',
-            '--runtime-config', 'batch/v2alpha1=true,apps/v1alpha1=true',
             '--yes', full_cluster_name,
         ], args)
         if not args.dry_run:


### PR DESCRIPTION
This option can't be set via `kops create cluster`.

As an option we could use a config file and create the cluster via `kops create -f cluster.yaml`.

Created #4 to track this.